### PR TITLE
Remove all previous hack code. Create a SDWebImageFLCoder to decode just FLAnimatedImage for GIF.

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,7 +3,7 @@ inhibit_all_warnings!
 
 target 'SDWebImageFLPlugin_Example' do
   pod 'SDWebImageFLPlugin', :path => '../'
-  pod 'SDWebImage/Core', :git => 'https://github.com/rs/SDWebImage.git', :branch => '5.x'
+  pod 'SDWebImage/Core', :path => '../../SDWebImage'
 
   target 'SDWebImageFLPlugin_Tests' do
     inherit! :search_paths

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,7 +3,7 @@ inhibit_all_warnings!
 
 target 'SDWebImageFLPlugin_Example' do
   pod 'SDWebImageFLPlugin', :path => '../'
-  pod 'SDWebImage/Core', :path => '../../SDWebImage'
+  pod 'SDWebImage/Core', :git => 'https://github.com/rs/SDWebImage.git', :branch => '5.x'
 
   target 'SDWebImageFLPlugin_Tests' do
     inherit! :search_paths

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -6,20 +6,26 @@ PODS:
     - SDWebImage/Core (>= 5.0.0-beta)
 
 DEPENDENCIES:
-  - SDWebImage/Core (from `../../SDWebImage`)
+  - SDWebImage/Core (from `https://github.com/rs/SDWebImage.git`, branch `5.x`)
   - SDWebImageFLPlugin (from `../`)
 
 EXTERNAL SOURCES:
   SDWebImage:
-    :path: ../../SDWebImage
+    :branch: 5.x
+    :git: https://github.com/rs/SDWebImage.git
   SDWebImageFLPlugin:
     :path: ../
 
+CHECKOUT OPTIONS:
+  SDWebImage:
+    :commit: aff324b0d09ab4a1736807ca1abc549032b9238a
+    :git: https://github.com/rs/SDWebImage.git
+
 SPEC CHECKSUMS:
   FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
-  SDWebImage: 71477761c34d186f16da28bd0b042992b37d0bc6
+  SDWebImage: 55c787b164fabe07f2a4d5307f6e1be7960fb9be
   SDWebImageFLPlugin: afb1876afe305cb2a20f091e8782ba552007805e
 
-PODFILE CHECKSUM: d1da73fa0e15a4b327e1549474c428bb91f3ee39
+PODFILE CHECKSUM: d45303c99b143f5fd7d828ef30667c31060a0484
 
 COCOAPODS: 1.4.0

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -6,26 +6,20 @@ PODS:
     - SDWebImage/Core (>= 5.0.0-beta)
 
 DEPENDENCIES:
-  - SDWebImage/Core (from `https://github.com/rs/SDWebImage.git`, branch `5.x`)
+  - SDWebImage/Core (from `../../SDWebImage`)
   - SDWebImageFLPlugin (from `../`)
 
 EXTERNAL SOURCES:
   SDWebImage:
-    :branch: 5.x
-    :git: https://github.com/rs/SDWebImage.git
+    :path: ../../SDWebImage
   SDWebImageFLPlugin:
     :path: ../
 
-CHECKOUT OPTIONS:
-  SDWebImage:
-    :commit: fe2fede60f9c6efcadfac8b90e8cae579656fffb
-    :git: https://github.com/rs/SDWebImage.git
-
 SPEC CHECKSUMS:
   FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
-  SDWebImage: 55c787b164fabe07f2a4d5307f6e1be7960fb9be
+  SDWebImage: 71477761c34d186f16da28bd0b042992b37d0bc6
   SDWebImageFLPlugin: afb1876afe305cb2a20f091e8782ba552007805e
 
-PODFILE CHECKSUM: d45303c99b143f5fd7d828ef30667c31060a0484
+PODFILE CHECKSUM: d1da73fa0e15a4b327e1549474c428bb91f3ee39
 
 COCOAPODS: 1.4.0

--- a/Example/SDWebImageFLPlugin/SDViewController.m
+++ b/Example/SDWebImageFLPlugin/SDViewController.m
@@ -8,7 +8,6 @@
 
 #import "SDViewController.h"
 #import <SDWebImageFLPlugin/SDWebImageFLPlugin.h>
-#import <FLAnimatedImage/FLAnimatedImageView.h>
 
 @interface SDViewController ()
 
@@ -18,6 +17,9 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    [[SDImageCodersManager sharedManager] addCoder:[SDWebImageFLCoder sharedCoder]];
+    
+    
 	// Do any additional setup after loading the view, typically from a nib.
     FLAnimatedImageView *animatedImageView = [[FLAnimatedImageView alloc] initWithFrame:self.view.frame];
     animatedImageView.contentMode = UIViewContentModeScaleAspectFit;

--- a/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/FLAnimatedImageView+WebCache.h
+++ b/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/FLAnimatedImageView+WebCache.h
@@ -15,33 +15,25 @@
 #import "FLAnimatedImage.h"
 #endif
 
+/**
+ * Optimal frame cache size of FLAnimatedImage during initializer. (1.0.11 version later)
+ * This value will help you set `optimalFrameCacheSize` arg of FLAnimatedImage initializer after image load.
+ * Defaults to 0.
+ */
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextOptimalFrameCacheSize;
+/**
+ * Predrawing control of FLAnimatedImage during initializer. (1.0.11 version later)
+ * This value will help you set `predrawingEnabled` arg of FLAnimatedImage initializer after image load.
+ * Defaults to YES.
+ */
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextPredrawingEnabled;
+
 
 /**
  *  A category for the FLAnimatedImage imageView class that hooks it to the SDWebImage system.
  *  Very similar to the base class category (UIImageView (WebCache))
  */
 @interface FLAnimatedImageView (WebCache)
-
-/**
- * Optimal frame cache size of FLAnimatedImage during initializer. (1.0.11 version later)
- * This value will help you set `optimalFrameCacheSize` arg of FLAnimatedImage initializer after image load.
- * Defaults to 0.
- */
-@property (nonatomic, assign) NSUInteger sd_optimalFrameCacheSize;
-
-/**
- * Predrawing control of FLAnimatedImage during initializer. (1.0.11 version later)
- * This value will help you set `predrawingEnabled` arg of FLAnimatedImage initializer after image load.
- * Defaults to YES.
- */
-@property (nonatomic, assign) BOOL sd_predrawingEnabled;
-
-/**
- * Cache control for associated FLAnimatedImage object for memory cache. When enabled, we will bind created FLAnimatedImage instance to UIImage, and store it into memory cache to avoid create this instance cause decoding performance. See `UIImage+FLAnimatedImage`.
- * When enabled, this may consume more memory, if you are facing memory issue, disable it and let FLAnimatedImage been created just in time and dealloced as it not been used. However, when disabled, this may impact performance since we need query disk cache, create FLAnimatedImage and decoding even when the current GIF url is cached.
- * Defatuls to YES;
- */
-@property (nonatomic, assign) BOOL sd_cacheFLAnimatedImage;
 
 /**
  * Load the image at the given url (either from cache or download) and load it in this imageView. It works with both static and dynamic images

--- a/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/FLAnimatedImageView+WebCache.m
+++ b/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/FLAnimatedImageView+WebCache.m
@@ -7,49 +7,11 @@
  */
 
 #import "FLAnimatedImageView+WebCache.h"
-#import "objc/runtime.h"
+
+SDWebImageContextOption _Nonnull const SDWebImageContextOptimalFrameCacheSize = @"optimalFrameCacheSize";
+SDWebImageContextOption _Nonnull const SDWebImageContextPredrawingEnabled = @"predrawingEnabled";
 
 @implementation FLAnimatedImageView (WebCache)
-
-// These property based options will moved to `SDWebImageContext` in 5.x, to allow per-image-request level options instead of per-imageView-level options
-- (NSUInteger)sd_optimalFrameCacheSize {
-    NSUInteger optimalFrameCacheSize = 0;
-    NSNumber *value = objc_getAssociatedObject(self, @selector(sd_optimalFrameCacheSize));
-    if ([value isKindOfClass:[NSNumber class]]) {
-        optimalFrameCacheSize = value.unsignedShortValue;
-    }
-    return optimalFrameCacheSize;
-}
-
-- (void)setSd_optimalFrameCacheSize:(NSUInteger)sd_optimalFrameCacheSize {
-    objc_setAssociatedObject(self, @selector(sd_optimalFrameCacheSize), @(sd_optimalFrameCacheSize), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-- (BOOL)sd_predrawingEnabled {
-    BOOL predrawingEnabled = YES;
-    NSNumber *value = objc_getAssociatedObject(self, @selector(sd_predrawingEnabled));
-    if ([value isKindOfClass:[NSNumber class]]) {
-        predrawingEnabled = value.boolValue;
-    }
-    return predrawingEnabled;
-}
-
-- (void)setSd_predrawingEnabled:(BOOL)sd_predrawingEnabled {
-    objc_setAssociatedObject(self, @selector(sd_predrawingEnabled), @(sd_predrawingEnabled), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-- (BOOL)sd_cacheFLAnimatedImage {
-    BOOL cacheFLAnimatedImage = YES;
-    NSNumber *value = objc_getAssociatedObject(self, @selector(sd_cacheFLAnimatedImage));
-    if ([value isKindOfClass:[NSNumber class]]) {
-        cacheFLAnimatedImage = value.boolValue;
-    }
-    return cacheFLAnimatedImage;
-}
-
-- (void)setSd_cacheFLAnimatedImage:(BOOL)sd_cacheFLAnimatedImage {
-    objc_setAssociatedObject(self, @selector(sd_cacheFLAnimatedImage), @(sd_cacheFLAnimatedImage), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
 
 - (void)sd_setImageWithURL:(nullable NSURL *)url {
     [self sd_setImageWithURL:url placeholderImage:nil options:0 progress:nil completed:nil];
@@ -85,43 +47,25 @@
                    context:(nullable SDWebImageContext *)context
                   progress:(nullable SDImageLoaderProgressBlock)progressBlock
                  completed:(nullable SDExternalCompletionBlock)completedBlock {
+    SDWebImageMutableContext *mutableContext;
+    if (context) {
+        mutableContext = [context mutableCopy];
+    } else {
+        mutableContext = [NSMutableDictionary dictionary];
+    }
+    mutableContext[SDWebImageContextSetImageOperationKey] = NSStringFromClass(self.class);
     __weak typeof(self)weakSelf = self;
     [self sd_internalSetImageWithURL:url
                     placeholderImage:placeholder
                              options:options
-                             context:context
+                             context:mutableContext
                        setImageBlock:^(UIImage *image, NSData *imageData) {
                            __strong typeof(weakSelf)strongSelf = weakSelf;
                            if (!strongSelf) {
                                return;
                            }
-                           // Step 1. Check memory cache (associate object)
-                           FLAnimatedImage *associatedAnimatedImage = image.sd_FLAnimatedImage;
-                           if (associatedAnimatedImage) {
-                               // Asscociated animated image exist
-                               strongSelf.animatedImage = associatedAnimatedImage;
-                               strongSelf.image = nil;
-                               return;
-                           }
-                           // Step 2. Check if original compressed image data is "GIF"
-                           BOOL isGIF = (image.sd_imageFormat == SDImageFormatGIF || [NSData sd_imageFormatForImageData:imageData] == SDImageFormatGIF);
-                           if (!isGIF) {
-                               strongSelf.image = image;
-                               strongSelf.animatedImage = nil;
-                               return;
-                           }
-                           // Step 3. Check if data exist or query disk cache
-                           if (!imageData) {
-                               NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url];
-                               imageData = [[SDImageCache sharedImageCache] diskImageDataForKey:key];
-                           }
-                           // Step 4. Create FLAnimatedImage
-                           FLAnimatedImage *animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData optimalFrameCacheSize:strongSelf.sd_optimalFrameCacheSize predrawingEnabled:strongSelf.sd_predrawingEnabled];
-                           // Step 5. Set animatedImage or normal image
+                           FLAnimatedImage *animatedImage = image.sd_FLAnimatedImage;
                            if (animatedImage) {
-                               if (strongSelf.sd_cacheFLAnimatedImage) {
-                                   image.sd_FLAnimatedImage = animatedImage;
-                               }
                                strongSelf.animatedImage = animatedImage;
                                strongSelf.image = nil;
                            } else {

--- a/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/FLAnimatedImageView+WebCache.m
+++ b/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/FLAnimatedImageView+WebCache.m
@@ -66,11 +66,12 @@ SDWebImageContextOption _Nonnull const SDWebImageContextPredrawingEnabled = @"pr
                            }
                            FLAnimatedImage *animatedImage = image.sd_FLAnimatedImage;
                            if (animatedImage) {
+                               // FLAnimatedImage framework contains a bug that cause GIF been rotated if previous rendered image orientation is not Up. We have to call `setImage:` with non-nil image to reset the state. See `https://github.com/rs/SDWebImage/issues/2402`
+                               strongSelf.image = animatedImage.posterImage;
                                strongSelf.animatedImage = animatedImage;
-                               strongSelf.image = nil;
                            } else {
-                               strongSelf.animatedImage = nil;
                                strongSelf.image = image;
+                               strongSelf.animatedImage = nil;
                            }
                        }
                             progress:progressBlock

--- a/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/SDWebImageFLCoder.h
+++ b/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/SDWebImageFLCoder.h
@@ -1,0 +1,18 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import <SDWebImage/SDWebImage.h>
+
+// A coder which decode the GIF image, into `FLAnimatedImage` representation and bind the associated object. See `UIImage+SDWebImageFLPlugin` for more detailed information.
+// When you want to use `FLAnimatedImageView` to load image, be sure to add this coder before `SDImageGIFCoder`, to ensure this coder been processed before `SDImageGIFCoder`
+
+@interface SDWebImageFLCoder : NSObject <SDImageCoder>
+
+@property (nonatomic, class, readonly, nonnull) SDWebImageFLCoder *sharedCoder;
+
+@end

--- a/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/SDWebImageFLCoder.m
+++ b/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/SDWebImageFLCoder.m
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "SDWebImageFLCoder.h"
+#import "FLAnimatedImageView+WebCache.h"
+
+@implementation SDWebImageFLCoder
+
++ (SDWebImageFLCoder *)sharedCoder {
+    static SDWebImageFLCoder *coder;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        coder = [[SDWebImageFLCoder alloc] init];
+    });
+    return coder;
+}
+
+- (BOOL)canDecodeFromData:(NSData *)data {
+    return ([NSData sd_imageFormatForImageData:data] == SDImageFormatGIF);
+}
+
+- (UIImage *)decodedImageWithData:(NSData *)data options:(SDImageCoderOptions *)options {
+    SDWebImageContext *context = options[SDImageCoderWebImageContext];
+    NSString *operationKey = context[SDWebImageContextSetImageOperationKey];
+    
+    // Check if image request come from `FLAnimatedImageView`
+    if ([operationKey isEqualToString:NSStringFromClass(FLAnimatedImageView.class)]) {
+        // Parse args
+        BOOL predrawingEnabled = YES;
+        if (context[SDWebImageContextPredrawingEnabled]) {
+            predrawingEnabled = [context[SDWebImageContextPredrawingEnabled] boolValue];
+        }
+        NSUInteger optimalFrameCacheSize = 0;
+        if (context[SDWebImageContextOptimalFrameCacheSize]) {
+            optimalFrameCacheSize = [context[SDWebImageContextOptimalFrameCacheSize] unsignedIntegerValue];
+        }
+        // Create FLAnimatedImage
+        FLAnimatedImage *animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:data optimalFrameCacheSize:optimalFrameCacheSize predrawingEnabled:predrawingEnabled];
+        if (!animatedImage) {
+            return nil;
+        }
+        
+        return [UIImage sd_imageWithFLAnimatedImage:animatedImage];
+    } else {
+        UIImage *image;
+        NSArray<id<SDImageCoder>> *coders = [SDImageCodersManager sharedManager].coders;
+        for (id<SDImageCoder> coder in coders.reverseObjectEnumerator) {
+            if (coder == self) {
+                continue;
+            }
+            if ([coder canDecodeFromData:data]) {
+                image = [coder decodedImageWithData:data options:options];
+                break;
+            }
+        }
+        
+        return image;
+    }
+}
+
+- (BOOL)canEncodeToFormat:(SDImageFormat)format {
+    return NO;
+}
+
+- (NSData *)encodedDataWithImage:(UIImage *)image format:(SDImageFormat)format options:(SDImageCoderOptions *)options {
+    return nil;
+}
+
+@end

--- a/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/SDWebImageFLCoder.m
+++ b/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/SDWebImageFLCoder.m
@@ -27,9 +27,10 @@
 - (UIImage *)decodedImageWithData:(NSData *)data options:(SDImageCoderOptions *)options {
     SDWebImageContext *context = options[SDImageCoderWebImageContext];
     NSString *operationKey = context[SDWebImageContextSetImageOperationKey];
+    Class imageViewClass = NSClassFromString(operationKey);
     
     // Check if image request come from `FLAnimatedImageView`
-    if ([operationKey isEqualToString:NSStringFromClass(FLAnimatedImageView.class)]) {
+    if (imageViewClass && [imageViewClass isSubclassOfClass:FLAnimatedImageView.class]) {
         // Parse args
         BOOL predrawingEnabled = YES;
         if (context[SDWebImageContextPredrawingEnabled]) {

--- a/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/UIImage+SDWebImageFLPlugin.h
+++ b/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/UIImage+SDWebImageFLPlugin.h
@@ -19,4 +19,13 @@
  */
 @property (nonatomic, strong, nullable) FLAnimatedImage *sd_FLAnimatedImage;
 
+/**
+ Create a UIImage instance, which bind FLAnimatedImage using the `sd_FLAnimatedImage` on it.
+ This will use `posterImage` on FLAnimatedImage to create a new UIImage and specify the associate object. To avoid cycle retain.
+
+ @param animatedImage FLAnimatedImage instance
+ @return The UIImage which bind FLAnimatedImage on it
+ */
++ (nullable instancetype)sd_imageWithFLAnimatedImage:(nullable FLAnimatedImage *)animatedImage;
+
 @end

--- a/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/UIImage+SDWebImageFLPlugin.m
+++ b/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/UIImage+SDWebImageFLPlugin.m
@@ -26,7 +26,7 @@
     if (!imageRef) {
         return nil;
     }
-    UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:posterImage.scale orientation:UIImageOrientationUp];
+    UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:posterImage.scale orientation:posterImage.imageOrientation];
     
     image.sd_FLAnimatedImage = animatedImage;
     image.sd_isDecoded = YES; // Avoid force decode and loss the associate object

--- a/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/UIImage+SDWebImageFLPlugin.m
+++ b/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/UIImage+SDWebImageFLPlugin.m
@@ -7,6 +7,7 @@
  */
 
 #import "UIImage+SDWebImageFLPlugin.h"
+#import <SDWebImage/SDWebImage.h>
 #import "objc/runtime.h"
 
 @implementation UIImage (SDWebImageFLPlugin)
@@ -17,6 +18,20 @@
 
 - (void)setSd_FLAnimatedImage:(FLAnimatedImage *)sd_FLAnimatedImage {
     objc_setAssociatedObject(self, @selector(sd_FLAnimatedImage), sd_FLAnimatedImage, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
++ (instancetype)sd_imageWithFLAnimatedImage:(FLAnimatedImage *)animatedImage {
+    UIImage *posterImage = animatedImage.posterImage;
+    CGImageRef imageRef = posterImage.CGImage;
+    if (!imageRef) {
+        return nil;
+    }
+    UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:posterImage.scale orientation:UIImageOrientationUp];
+    
+    image.sd_FLAnimatedImage = animatedImage;
+    image.sd_isDecoded = YES; // Avoid force decode and loss the associate object
+    
+    return image;
 }
 
 @end

--- a/SDWebImageFLPlugin/Module/SDWebImageFLPlugin.h
+++ b/SDWebImageFLPlugin/Module/SDWebImageFLPlugin.h
@@ -12,6 +12,7 @@
 
 #import <SDWebImageFLPlugin/FLAnimatedImageView+WebCache.h>
 #import <SDWebImageFLPlugin/UIImage+SDWebImageFLPlugin.h>
+#import <SDWebImageFLPlugin/SDWebImageFLCoder.h>
 
 
 FOUNDATION_EXPORT double SDWebImageFLPluginVersionNumber;


### PR DESCRIPTION
This PR, contains a possible solution for https://github.com/rs/SDWebImage/pull/2404

### Reason

We previouslly, in SDWebImage 4.x, have no choice to hack and create `FLAnimatedImage` during setImageBlock. However, it's a wrong solution, whatever from the architecture or the task side.

The decoding process, should always happend on the `Coder` level, which receive a compressed image data and generate image representation. Though `FLAnimatedImageView` only accept `FLAnimatedImage`, which is not a `UIImage` subclass. However, we use associated object to bind it on a normal `UIImage`, so this can solve the problem.

### Design
We should move the decoding code, into a single custom coder, called `SDWebImageFLCoder`. Which will produce a `UIImage` which has a `FLAnimatedImage` associated to it. Quite simple.

However, in order to not affect the normal image decoding process on normal `UIImageView` or `SDAnimatedImageView`. We should only filter that the orignal image request for GIF, is come from `FLAnimatedImageView`. So we need the support from `SDImageCoderOption`, to pass the context arg (Introduced in 5.0.0-beta) to the coder, and check it.

Another consideration, from 4.x, we should move those args to create `FLAnimatedImage`, like `predrawEnabled, optimalCacheSize`, to the context option level. Because it's related to `FLAnimatedImage` level, but not `FLAnimatedImageView` level.

### Implemenatation

```objecitve-c
@interface SDWebImageFLCoder : NSObject <SDImageCoder>
@property (nonatomic, class, readonly, nonnull) SDWebImageFLCoder *sharedCoder;
@end

@implemenation SDWebImageFLCoder
- (UIImage *)decodedImageWithData:(NSData *)data options:(SDImageCoderOptions *)options {
    if (original request from FLAnimatedImageView) {
        FLAnimatedImage *animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:data];
        return [UIImage sd_imageWithFLAnimatedImage:animatedImage];
    } else {
        return [SDImageGIFCoder.sharedCoder decodedImageWithData:data options:options];
    }
}

@end
```
What for user: Remember to add `SDWebImageFLCoder`, to the coders manager at the beginning, ensure its order is higher than `SDImageGIFCoder`. (in AppDelegate or somewhere)