### PR TITLE
Adopt SDWebImage's memory cache cost function, fix the nullable issue

### DIFF
--- a/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/SDFLAnimatedImage.h
+++ b/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/SDFLAnimatedImage.h
@@ -30,9 +30,9 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextPredra
 @interface SDFLAnimatedImage : UIImage <SDAnimatedImage>
 
 /**
- The `FLAnimatedImage` instance for GIF representation
+ The `FLAnimatedImage` instance for GIF representation. This property should be nonnull.
  */
-@property (nonatomic, strong, nullable, readonly) FLAnimatedImage *animatedImage;
+@property (nonatomic, strong, nonnull, readonly) FLAnimatedImage *animatedImage;
 
 /**
  Create the wrapper with specify `FLAnimatedImage` instance. The instance should be nonnull.


### PR DESCRIPTION
See SDWebImage/SDWebImage#2568

This PR add the memory cache cost function for custom image class `SDFLAnimatedImage`. Which is a wrapper for `FLAnimatedImage`. It store a internal frame buffer (called `window`) with a limit size.