### PR TITLE
Override the UIImage+Metadata category method to provide the correct value for SDFLAnimatedImage

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "SDWebImage/SDWebImage" ~> 5.0
+github "SDWebImage/SDWebImage" ~> 5.6
 github "Flipboard/FLAnimatedImage" >= 1.0.11

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "Flipboard/FLAnimatedImage" "1.0.14"
-github "SDWebImage/SDWebImage" "5.0.0"
+github "SDWebImage/SDWebImage" "5.6.0"

--- a/SDWebImageFLPlugin.podspec
+++ b/SDWebImageFLPlugin.podspec
@@ -25,6 +25,6 @@ This project adds a plugin for FLAnimatedImage into SDWebImage, for loading anim
   s.source_files = 'SDWebImageFLPlugin/Classes/**/*', 'SDWebImageFLPlugin/Module/SDWebImageFLPlugin.h'
   s.module_map = 'SDWebImageFLPlugin/Module/SDWebImageFLPlugin.modulemap'
 
-  s.dependency 'SDWebImage/Core', '~> 5.0'
+  s.dependency 'SDWebImage/Core', '~> 5.6'
   s.dependency 'FLAnimatedImage', '>= 1.0.11'
 end

--- a/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/SDFLAnimatedImage.m
+++ b/SDWebImageFLPlugin/Classes/FLAnimatedImageBridge/SDFLAnimatedImage.m
@@ -145,3 +145,31 @@ SDWebImageContextOption _Nonnull const SDWebImageContextPredrawingEnabled = @"pr
 }
 
 @end
+
+@implementation SDFLAnimatedImage (Metadata)
+
+- (BOOL)sd_isAnimated {
+    return YES;
+}
+
+- (NSUInteger)sd_imageLoopCount {
+    return self.animatedImageLoopCount;
+}
+
+- (void)setSd_imageLoopCount:(NSUInteger)sd_imageLoopCount {
+    return;
+}
+
+- (SDImageFormat)sd_imageFormat {
+    return SDImageFormatGIF;
+}
+
+- (void)setSd_imageFormat:(SDImageFormat)sd_imageFormat {
+    return;
+}
+
+- (BOOL)sd_isVector {
+    return NO;
+}
+
+@end


### PR DESCRIPTION
This is what SDWebImage 5.6.0 behavior. Not a force change, but all the `SDAnimatedImage` has already adopt this design.